### PR TITLE
fix: Ensure appropriate quoting for case sensitive tenant names

### DIFF
--- a/pkg/drivertest/drivertest.go
+++ b/pkg/drivertest/drivertest.go
@@ -136,6 +136,22 @@ func testMigrateTenantModels(t *testing.T, db *multitenancy.DB, opts Options) {
 		})
 		assert.NoError(t, err)
 	})
+
+	t.Run("Issue100 Quoting", func(t *testing.T) {
+		if opts.IsMock {
+			t.Skip("skipping case sensitive test for mock implementations")
+		}
+		ctx := context.Background()
+		tenant := &testmodels.Tenant{ID: "Tenant_One"}
+		err := db.FirstOrCreate(tenant).Error
+		require.NoError(t, err)
+
+		err = db.RegisterModels(ctx, testmodels.MakePrivateModels(t)...)
+		require.NoError(t, err)
+
+		err = db.MigrateTenantModels(ctx, tenant.ID)
+		assert.NoError(t, err)
+	})
 }
 
 // testOffboardTenant tests the OffboardTenant method.


### PR DESCRIPTION
Fixes case-sensitive tenant name handling in PostgreSQL and MySQL drivers by properly quoting schema and database names in path operations.

## Changes

- **postgres/schema/schema.go**: Use `QuoteTo()` in `SetSearchPath()` function
- **mysql/schema/schema.go**: Use `QuoteTo()` in `UseDatabase()` function
- Added test coverage for case-sensitive tenant names to prevent regression (see [`TestIssue100` comments below](https://github.com/bartventer/gorm-multitenancy/pull/101#issuecomment-3062416290))

Fixes #100